### PR TITLE
Update plugin to support Webpack 4 Promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,10 +51,10 @@ HtmlReplaceWebpackPlugin.prototype.apply = function(compiler)
   {
     // console.log('The compiler is starting a new compilation...')
     compilation.plugin('html-webpack-plugin-before-html-processing',
-      function(htmlPluginData, callback)
+      function(htmlPluginData)
       {
         htmlPluginData.html = _this.replace(htmlPluginData.html)
-        callback(null, htmlPluginData)
+        return htmlPluginData;
       })
   })
 }


### PR DESCRIPTION
Webpack 4 uses promises for plugins now so no callback is passed from the html-webpack-plugin and instead your function should just return its data.